### PR TITLE
Export it

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -19,3 +19,5 @@ class Type {
     }
   }
 }
+
+module.exports = Type;


### PR DESCRIPTION
This is required because without it, you wouldn't be able to use your "type() module" in tests/test.js.